### PR TITLE
Fix relativ path for the import to work after pip install

### DIFF
--- a/codebeamer/client.py
+++ b/codebeamer/client.py
@@ -1,5 +1,5 @@
 import requests, json
-from .mixins.project import ProjectMixin
+from codebeamer.mixins.project import ProjectMixin
 
 
 class Codebeamer(ProjectMixin):


### PR DESCRIPTION
After pip install on windows, the sub folder mixins is missing in the python\lib\site-packages\codebeamer. 
Need to copy manually or modify the setup. I propose to modify "from .mixins.project import ProjectMixin" by "from codebeamer.mixins.project import ProjectMixin"