### PR TITLE
PIP SETUP FIX

### DIFF
--- a/codebeamer/mixins/__init__.py
+++ b/codebeamer/mixins/__init__.py
@@ -1,0 +1,1 @@
+from .project import ProjectMixin

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import pathlib
-from setuptools import setup
+from setuptools import setup , find_packages
 
 # The directory containing this file
 HERE = pathlib.Path(__file__).parent
@@ -23,7 +23,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
     ],
-    packages=["codebeamer"],
+    packages=find_packages(include=['codebeamer', 'codebeamer.*']),
     include_package_data=True,
     install_requires=[
         'requests',


### PR DESCRIPTION
When someone tries to install codebeamer package via pip install git+REPO for example, the Mixins directory isn't cloned to python packages with the codebeamer folder .
this PR fixes the issue.